### PR TITLE
[TPY] Missing keystore.trusty in PRODUCT_PACKAGES 

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0015-TPY-Missing-keystore.trusty-in-PRODUCT_PACKAGES.patch
+++ b/bsp_diff/caas/device/intel/mixins/0015-TPY-Missing-keystore.trusty-in-PRODUCT_PACKAGES.patch
@@ -1,0 +1,26 @@
+From 170418db43b4aef121af9a8b508ad2a5fe1dc080 Mon Sep 17 00:00:00 2001
+From: "Kothapeta, BikshapathiX" <bikshapathix.kothapeta@intel.com>
+Date: Tue, 21 Jun 2022 12:41:28 +0530
+Subject: [PATCH] [TPY] Missing keystore.trusty in PRODUCT_PACKAGES
+
+missing keystore.trusty in PRODUCT_PACKAGES
+
+Tracked-On: OAM-102535
+Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>
+
+diff --git a/groups/trusty/true/product.mk b/groups/trusty/true/product.mk
+index 18cdcfd..6a4851a 100644
+--- a/groups/trusty/true/product.mk
++++ b/groups/trusty/true/product.mk
+@@ -1,5 +1,8 @@
+ {{#enable_hw_sec}}
+ 
++PRODUCT_PACKAGES += \
++        keystore.trusty
++
+ PRODUCT_PACKAGES += \
+ 	libtrusty \
+ 	storageproxyd \
+-- 
+2.36.1
+


### PR DESCRIPTION
missing android.hardware.keymaster@3.0-impl and
android.hardware.keymaster@3.0-service in PRODUCT_PACKAGES

Tracked-On: OAM-102535
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>