### PR TITLE
[Config] disable fw cache config

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0015-Config-disable-fw-cache-config.patch
+++ b/bsp_diff/caas/device/intel/mixins/0015-Config-disable-fw-cache-config.patch
@@ -1,0 +1,29 @@
+From e48325a8c0709f4a422eeb17e2f15e607c047a70 Mon Sep 17 00:00:00 2001
+From: vdanix <vishwanathx.dani@intel.com>
+Date: Tue, 20 Dec 2022 13:47:49 +0530
+Subject: [PATCH] [Config] disable fw cache config
+
+as per vts kernel compatablity test suit
+test case is expecting CONFIG_FW_CACHE to n
+config CONFIG_FW_CACHE, value = y but required n
+
+Tracked-On: OAM-105308
+Signed-off-by: vdanix <vishwanathx.dani@intel.com>
+Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>
+
+diff --git a/groups/kernel/gmin64/config-lts/lts2019-chromium/x86_64_defconfig b/groups/kernel/gmin64/config-lts/lts2019-chromium/x86_64_defconfig
+index e948983..0adb795 100644
+--- a/groups/kernel/gmin64/config-lts/lts2019-chromium/x86_64_defconfig
++++ b/groups/kernel/gmin64/config-lts/lts2019-chromium/x86_64_defconfig
+@@ -1584,7 +1584,7 @@ CONFIG_EXTRA_FIRMWARE_DIR="${EXTRA_FW_DIR}"
+ CONFIG_FW_LOADER_USER_HELPER=y
+ CONFIG_FW_LOADER_USER_HELPER_FALLBACK=y
+ # CONFIG_FW_LOADER_COMPRESS is not set
+-CONFIG_FW_CACHE=y
++# CONFIG_FW_CACHE is not set
+ # end of Firmware loader
+ 
+ CONFIG_WANT_DEV_COREDUMP=y
+-- 
+2.39.0
+


### PR DESCRIPTION
as per vts kernel compatablity test suit
test case is expecting CONFIG_FW_CACHE to n
config CONFIG_FW_CACHE, value = y but required n

Tracked-On: OAM-105308
Signed-off-by: vdanix <vishwanathx.dani@intel.com>
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>