### PR TITLE
Fix logic to display gvt prompt

### DIFF
--- a/bsp_diff/caas/device/intel/civ/host/vm-manager/0038-Fix-logic-to-display-gvt-prompt.patch
+++ b/bsp_diff/caas/device/intel/civ/host/vm-manager/0038-Fix-logic-to-display-gvt-prompt.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Basil Chew <basil.chew@intel.com>
+Date: Wed, 14 Dec 2022 09:55:53 +0800
+Subject: [PATCH] Fix logic to display gvt prompt
+
+Changes:
+- improved string matching to handle both hex and decimal
+- retained only SRIOV setting in string match
+
+Change-Id: I126d013b250d847ea80ed5788cd8a28c950a2409
+---
+ scripts/setup_host.sh | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/scripts/setup_host.sh b/scripts/setup_host.sh
+index 26a923a..fdbe18d 100755
+--- a/scripts/setup_host.sh
++++ b/scripts/setup_host.sh
+@@ -126,8 +126,9 @@ function ubu_build_ovmf_gvt(){
+ 
+ function ubu_enable_host_gvt(){
+ 
+-    if [[ ! `cat /etc/default/grub` =~ "i915.enable_guc=0x7 udmabuf.list_limit=8192" ]] &&
++    if [[ ! `cat /etc/default/grub` =~ "i915.enable_guc="(0x)?0*"7" ]] &&
+        [[ ! `cat /etc/default/grub` =~ "i915.enable_gvt=1" ]]; then
++
+         read -p "The grub entry in '/etc/default/grub' will be updated for enabling GVT-g and GVT-d, do you want to continue? [Y/n]" res
+         if [ x$res = xn ]; then
+             return
+-- 
+2.17.1
+


### PR DESCRIPTION
Changes:

- improved string matching to handle both hex and decimal
- retained only SRIOV setting in string match

Change-Id: Idca0fa12a813060c6c8fc36fa19dc71fdd410d19
Tracked-On: OAM-105286
Signed-off-by: Suresh, Prashanth <prashanth.suresh@intel.com>