### PR TITLE
CCodecBufferChannel: Report an error after reallocation failures.

### DIFF
--- a/aosp_diff/caas/frameworks/av/0001-CCodecBufferChannel-Report-an-error-after-reallocati.patch
+++ b/aosp_diff/caas/frameworks/av/0001-CCodecBufferChannel-Report-an-error-after-reallocati.patch
@@ -1,0 +1,57 @@
+From f070ce3db073b228e77d5e06a8fd43df7f019e5b Mon Sep 17 00:00:00 2001
+From: Sungtak Lee <taklee@google.com>
+Date: Wed, 15 Jun 2022 00:49:26 +0000
+Subject: [PATCH] CCodecBufferChannel: Report an error after reallocation
+ failures
+
+Output buffer conversion failures trigger endless reallocations of
+output buffers. Report an error in the case.
+
+Bug: 235610661
+Bug: 236087159
+Change-Id: Id2b6a25f4fdfa244dc64b15fc19c2fa899a61bae
+---
+ media/codec2/sfplugin/CCodecBufferChannel.cpp | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/media/codec2/sfplugin/CCodecBufferChannel.cpp b/media/codec2/sfplugin/CCodecBufferChannel.cpp
+index 307396b356..e78dd5c413 100644
+--- a/media/codec2/sfplugin/CCodecBufferChannel.cpp
++++ b/media/codec2/sfplugin/CCodecBufferChannel.cpp
+@@ -1935,6 +1935,9 @@ void CCodecBufferChannel::sendOutputBuffers() {
+     sp<MediaCodecBuffer> outBuffer;
+     std::shared_ptr<C2Buffer> c2Buffer;
+ 
++    constexpr int kMaxReallocTry = 5;
++    int reallocTryNum = 0;
++
+     while (true) {
+         Mutexed<Output>::Locked output(mOutput);
+         if (!output->buffers) {
+@@ -1942,6 +1945,9 @@ void CCodecBufferChannel::sendOutputBuffers() {
+         }
+         action = output->buffers->popFromStashAndRegister(
+                 &c2Buffer, &index, &outBuffer);
++        if (action != OutputBuffers::REALLOCATE) {
++            reallocTryNum = 0;
++        }
+         switch (action) {
+         case OutputBuffers::SKIP:
+             return;
+@@ -1952,6 +1958,13 @@ void CCodecBufferChannel::sendOutputBuffers() {
+             mCallback->onOutputBufferAvailable(index, outBuffer);
+             break;
+         case OutputBuffers::REALLOCATE:
++            if (++reallocTryNum > kMaxReallocTry) {
++                output.unlock();
++                ALOGE("[%s] sendOutputBuffers: tried %d realloc and failed",
++                          mName, kMaxReallocTry);
++                mCCodecCallback->onError(UNKNOWN_ERROR, ACTION_CODE_FATAL);
++                return;
++            }
+             if (!output->buffers->isArrayMode()) {
+                 output->buffers =
+                     output->buffers->toArrayMode(output->numSlots);
+-- 
+2.39.0
+


### PR DESCRIPTION
Output buffer conversion failures trigger endless reallocations of output buffers. Report an error in the case.

This changes are taken from horizontal celadon(Android-T).

Google source code commit reference:
https://android.googlesource.com/platform/frameworks/av/+/8ceef4d17fad183bafc2afb587bdca667c4cff1e

Tracked-On: OAM-105250
Signed-off-by: Vasoya,Nikhilx <nikhilx.vasoya@intel.com>