### PR TITLE
MediaSDK_C2 refactor regression.

### DIFF
--- a/bsp_diff/caas/vendor/intel/mediasdk_c2/0007-MediaSDK_C2-refactor-regression.patch
+++ b/bsp_diff/caas/vendor/intel/mediasdk_c2/0007-MediaSDK_C2-refactor-regression.patch
@@ -1,0 +1,66 @@
+From 27b38bb71bd24288ee55f94daf12328df4911d12 Mon Sep 17 00:00:00 2001
+From: "Kothapeta, BikshapathiX" <bikshapathix.kothapeta@intel.com>
+Date: Tue, 17 Jan 2023 11:18:13 +0530
+Subject: [PATCH] MediaSDK_C2 refactor regression.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+call the component’s function directly(skip codec).
+So that we set the outputPoolId to PLATFORM_START, it will use the
+BUFFERQUEUE allocator, but no surface was set. That’s why you see
+ igbp_id is 0 and igbp_slot is ~0(0xffffffff).
+
+Tracked-On:
+Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>
+
+diff --git a/c2_components/include/mfx_c2_decoder_component.h b/c2_components/include/mfx_c2_decoder_component.h
+index d3e2f15..d5842cc 100755
+--- a/c2_components/include/mfx_c2_decoder_component.h
++++ b/c2_components/include/mfx_c2_decoder_component.h
+@@ -215,7 +215,7 @@ private:
+     std::shared_ptr<MfxFramePoolAllocator> m_allocator; // used when Video memory output
+     // for pre-allocation when Video memory is chosen and always when System memory output
+     std::shared_ptr<C2BlockPool> m_c2Allocator;
+-    C2BlockPool::local_id_t m_outputPoolId = C2BlockPool::PLATFORM_START;
++    C2BlockPool::local_id_t m_outputPoolId = C2BlockPool::BASIC_GRAPHIC;
+     std::unique_ptr<MfxGrallocAllocator> m_grallocAllocator;
+     std::atomic<bool> m_bFlushing{false};
+ 
+diff --git a/c2_components/src/mfx_c2_decoder_component.cpp b/c2_components/src/mfx_c2_decoder_component.cpp
+index 0c54e51..532585e 100755
+--- a/c2_components/src/mfx_c2_decoder_component.cpp
++++ b/c2_components/src/mfx_c2_decoder_component.cpp
+@@ -1172,7 +1172,7 @@ mfxStatus MfxC2DecoderComponent::InitDecoder(std::shared_ptr<C2BlockPool> c2_all
+             uint64_t usage, igbp_id;
+             android::_UnwrapNativeCodec2GrallocMetadata(out_block->handle(), &width, &height, &format, &usage,
+                                                         &stride, &generation, &igbp_id, &igbp_slot);
+-            if (!igbp_id && !igbp_slot)
++            if ((!igbp_id && !igbp_slot) || (!igbp_id && igbp_slot == 0xffffffff))
+             {
+                 // No surface & BQ
+                 m_mfxVideoParams.IOPattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
+diff --git a/c2_components/src/mfx_c2_encoder_component.cpp b/c2_components/src/mfx_c2_encoder_component.cpp
+index 2f81109..ff9d701 100755
+--- a/c2_components/src/mfx_c2_encoder_component.cpp
++++ b/c2_components/src/mfx_c2_encoder_component.cpp
+@@ -942,6 +942,7 @@ mfxStatus MfxC2EncoderComponent::InitVPP(C2FrameData& buf_pack)
+ 
+     std::unique_ptr<C2ConstGraphicBlock> c_graph_block;
+     std::unique_ptr<const C2GraphicView> c2_graphic_view_;
++
+     res = GetC2ConstGraphicBlock(buf_pack, &c_graph_block);
+     if(C2_OK != res) return MFX_ERR_NONE;
+ 
+@@ -976,7 +977,7 @@ mfxStatus MfxC2EncoderComponent::InitVPP(C2FrameData& buf_pack)
+         uint64_t usage, igbp_id;
+         android::_UnwrapNativeCodec2GrallocMetadata(c_graph_block->handle(), &width, &height, &format, &usage,
+                                                 &stride, &generation, &igbp_id, &igbp_slot);
+-        if (!igbp_id && !igbp_slot) {
++        if ((!igbp_id && !igbp_slot) || (!igbp_id && igbp_slot == 0xffffffff)) {
+             //No surface & BQ
+             m_mfxVideoParamsConfig.IOPattern = MFX_IOPATTERN_IN_SYSTEM_MEMORY;
+ #ifdef USE_ONEVPL
+-- 
+2.39.0
+


### PR DESCRIPTION
call the component’s function directly(skip codec). So that we set the outputPoolId to PLATFORM_START, it will use the BUFFERQUEUE allocator, but no surface was set. That’s why you see igbp_id is 0 and igbp_slot is ~0(0xffffffff)

Tracked-On:
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>