### PR TITLE
Change the MinInputBufferSize to 1M

### DIFF
--- a/bsp_diff/caas/vendor/intel/mediasdk_c2/0009-Change-the-MinInputBufferSize-to-1M.patch
+++ b/bsp_diff/caas/vendor/intel/mediasdk_c2/0009-Change-the-MinInputBufferSize-to-1M.patch
@@ -1,0 +1,54 @@
+From f2b2b18eff3e5e89f5b3560567b750233aa58176 Mon Sep 17 00:00:00 2001
+From: vdanix <vishwanathx.dani@intel.com>
+Date: Mon, 6 Feb 2023 11:33:59 +0530
+Subject: [PATCH] Change the MinInputBufferSize to 1M
+
+Using 2M is with Software Codec calculation causing memory overfllow in CTS.
+Reduce it to 1M.
+
+Tracked-On: OAM-105733
+Signed-off-by: vdanix <vishwanathx.dani@intel.com>
+
+diff --git a/c2_components/src/mfx_c2_decoder_component.cpp b/c2_components/src/mfx_c2_decoder_component.cpp
+index 306f002..26419c3 100755
+--- a/c2_components/src/mfx_c2_decoder_component.cpp
++++ b/c2_components/src/mfx_c2_decoder_component.cpp
+@@ -42,7 +42,7 @@ using namespace android;
+ constexpr uint32_t MIN_W = 176;
+ constexpr uint32_t MIN_H = 144;
+ constexpr c2_nsecs_t TIMEOUT_NS = MFX_SECOND_NS;
+-constexpr uint64_t kMinInputBufferSize = 2 * WIDTH_2K * HEIGHT_2K;
++constexpr uint64_t kMinInputBufferSize = 1 * WIDTH_1K * HEIGHT_1K;
+ constexpr uint64_t kDefaultConsumerUsage =
+     (GRALLOC_USAGE_HW_TEXTURE | GRALLOC_USAGE_HW_COMPOSER);
+ 
+@@ -96,10 +96,8 @@ C2R MfxC2DecoderComponent::MaxInputSizeSetter(bool mayBlock, C2P<C2StreamMaxBuff
+                                 const C2P<C2StreamMaxPictureSizeTuning::output> &maxSize) {
+     (void)mayBlock;
+     // assume compression ratio of 2
+-    me.set().value = c2_max((((maxSize.v.width + 15) / 16)
+-            * ((maxSize.v.height + 15) / 16) * 192), kMinInputBufferSize);
+-    ALOGD("zyc, input size = %d", me.set().value);
+-    me.set().value = kMinInputBufferSize;
++     me.set().value = c2_max((((maxSize.v.width + 63) / 64) * ((maxSize.v.height + 63) / 64) * 3072),
++		     kMinInputBufferSize);
+     return C2R::Ok();
+ }
+ 
+diff --git a/c2_utils/include/mfx_defs.h b/c2_utils/include/mfx_defs.h
+index 0743513..46bdb01 100755
+--- a/c2_utils/include/mfx_defs.h
++++ b/c2_utils/include/mfx_defs.h
+@@ -64,6 +64,9 @@ extern mfxVersion g_required_mfx_version;
+ #define WIDTH_2K 2048
+ #define HEIGHT_2K 2048
+ 
++#define WIDTH_1K 1024
++#define HEIGHT_1K 1024
++
+ #define MIN_WIDTH_4K 3840
+ #define MIN_HEIGHT_4K 2160
+ #define MIN_WIDTH_8K 7680
+-- 
+2.39.1
+


### PR DESCRIPTION
Using 2M is with Software Codec calculation causing memory overfllow in CTS. Reduce it to 1M.

Tracked-On: OAM-105733
Signed-off-by: vdanix <vishwanathx.dani@intel.com>