### PR TITLE
Add getCapturePosition implementation

### DIFF
--- a/bsp_diff/caas/vendor/intel/external/project-celadon/audio/0001-Add-getCapturePosition-implementation.patch
+++ b/bsp_diff/caas/vendor/intel/external/project-celadon/audio/0001-Add-getCapturePosition-implementation.patch
@@ -1,0 +1,182 @@
+From f32ac2f04058f84968644b90239d7847274bbc72 Mon Sep 17 00:00:00 2001
+From: "Kothapeta, BikshapathiX" <bikshapathix.kothapeta@intel.com>
+Date: Wed, 8 Feb 2023 17:49:00 +0530
+Subject: [PATCH] Add getCapturePosition implementation
+
+Add getCapturePosition method implementation in HAL
+added methods to calculate time and frames read.
+VtsHalAudioV7_0Target Tests Fixed
+
+Tracked-On: OAM-102967
+Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>
+
+diff --git a/primary/audio_hw.c b/primary/audio_hw.c
+index e4394c5..9e6cf83 100755
+--- a/primary/audio_hw.c
++++ b/primary/audio_hw.c
+@@ -65,6 +65,12 @@
+ #define SAMPLE_SIZE_IN_BYTES          2
+ #define SAMPLE_SIZE_IN_BYTES_STEREO   4
+ 
++#define NANOS_PER_MICROSECOND  ((int64_t)1000)
++#define NANOS_PER_MILLISECOND  (NANOS_PER_MICROSECOND * 1000)
++#define MICROS_PER_MILLISECOND 1000
++#define MILLIS_PER_SECOND      1000
++#define NANOS_PER_SECOND       (NANOS_PER_MILLISECOND * MILLIS_PER_SECOND)
++
+ //#define DEBUG_PCM_DUMP
+ 
+ #ifdef DEBUG_PCM_DUMP
+@@ -175,16 +181,33 @@ struct stream_in {
+     struct audio_config req_config;
+     bool unavailable;
+     bool standby;
+-
++    unsigned int frames_read;
++    uint64_t timestamp_nsec;
+     struct audio_device *dev;
+ };
+ 
++/* 'bytes' are the number of bytes written to audio FIFO, for which 'timestamp' is valid.
++ * 'available' is the number of frames available to read (for input) or yet to be played
++ * (for output) frames in the PCM buffer.
++ * timestamp and available are updated by pcm_get_htimestamp(), so they use the same
++ * datatypes as the corresponding arguments to that function. */
++
++struct aec_info {
++    struct timespec timestamp;
++    uint64_t timestamp_usec;
++    unsigned int available;
++    size_t bytes;
++};
++
+ static uint32_t out_get_sample_rate(const struct audio_stream *stream);
+ static size_t out_get_buffer_size(const struct audio_stream *stream);
+ static audio_format_t out_get_format(const struct audio_stream *stream);
+ static uint32_t in_get_sample_rate(const struct audio_stream *stream);
+ static size_t in_get_buffer_size(const struct audio_stream *stream);
+ static audio_format_t in_get_format(const struct audio_stream *stream);
++static int getCapturePosition(const struct audio_stream_in *stream, int64_t* frames, int64_t* time1);
++static inline int64_t audio_utils_ns_from_timespec(const struct timespec *ts);
++static int get_pcm_timestamp(struct pcm* pcm, uint32_t sample_rate, struct aec_info* info, bool isOutput);
+ 
+ static void select_devices(struct audio_device *adev)
+ {
+@@ -706,6 +729,24 @@ static int out_get_presentation_position(const struct audio_stream_out *stream,
+     return ret;
+ }
+ 
++static int getCapturePosition(const struct audio_stream_in *stream, int64_t* frames, int64_t* time1){
++    if (stream == NULL || frames == NULL || time1 == NULL) {
++        return -EINVAL;
++     }
++    struct stream_in* in = (struct stream_in*)stream;
++
++    *frames = in->frames_read;
++    *time1 = in->timestamp_nsec;
++    ALOGV("%s: frames_read: %d, timestamp (nsec): %" PRIu64, __func__, in->frames_read, *time1);
++
++    return 0;
++}
++
++static inline int64_t audio_utils_ns_from_timespec(const struct timespec *ts)
++{
++	    return ts->tv_sec * 1000000000LL + ts->tv_nsec;
++}
++
+ static int out_add_audio_effect(const struct audio_stream *stream __unused, effect_handle_t effect __unused)
+ {
+     ALOGV("out_add_audio_effect: %p", effect);
+@@ -880,6 +921,40 @@ static int in_set_gain(struct audio_stream_in *stream __unused, float gain __unu
+     return 0;
+ }
+ 
++static void timestamp_adjust(struct timespec* ts, ssize_t frames, uint32_t sampling_rate) {
++    /* This function assumes the adjustment (in nsec) is less than the max value of long,
++     * which for 32-bit long this is 2^31 * 1e-9 seconds, slightly over 2 seconds.
++     * For 64-bit long it is  9e+9 seconds. */
++    long adj_nsec = (frames / (float) sampling_rate) * 1E9L;
++    ts->tv_nsec += adj_nsec;
++    while (ts->tv_nsec > 1E9L) {
++       ts->tv_sec++;
++       ts->tv_nsec -= 1E9L;
++    }
++    if (ts->tv_nsec < 0) {
++        ts->tv_sec--;
++        ts->tv_nsec += 1E9L;
++    }
++}
++
++static int get_pcm_timestamp(struct pcm* pcm, uint32_t sample_rate, struct aec_info* info, bool isOutput) {
++    int ret = 0;
++    if (pcm_get_htimestamp(pcm, &info->available, &info->timestamp) < 0) {
++        ALOGE("Error getting PCM timestamp!");
++        info->timestamp.tv_sec = 0;
++        info->timestamp.tv_nsec = 0;
++        return -EINVAL;
++    }
++    ssize_t frames;
++    if (isOutput) {
++       frames = pcm_get_buffer_size(pcm) - info->available;
++    } else {
++       frames = -info->available; /* rewind timestamp */
++    }
++    timestamp_adjust(&info->timestamp, frames, sample_rate);
++    return ret;
++}
++
+ static ssize_t in_read(struct audio_stream_in *stream, void* buffer,
+                        size_t bytes)
+ {
+@@ -928,6 +1003,19 @@ static ssize_t in_read(struct audio_stream_in *stream, void* buffer,
+         int16_t *buf_out = (int16_t *) malloc (buf_size_out);
+         int16_t *buf_in = (int16_t *) malloc (buf_size_in);
+         int16_t *buf_remapped = (int16_t *) malloc (buf_size_remapped);
++	const uint64_t time_increment_nsec = (uint64_t)bytes * NANOS_PER_SECOND /
++		audio_stream_in_frame_size(stream) /
++		in_get_sample_rate(&stream->common);
++
++	if (in->timestamp_nsec == 0) {
++                  struct timespec now;
++                  clock_gettime(CLOCK_MONOTONIC, &now);
++                  const uint64_t timestamp_nsec = audio_utils_ns_from_timespec(&now);
++                  in->timestamp_nsec = timestamp_nsec;
++        } else {
++                  in->timestamp_nsec += time_increment_nsec;
++        }
++        const uint64_t time_increment_usec = time_increment_nsec / 1000;
+ 
+         if(adev->voip_in_resampler == NULL) {
+             int ret = create_resampler(bt_in_config.rate /*src rate*/, in->pcm_config->rate /*dst rate*/, in->pcm_config->channels/*dst channels*/,
+@@ -953,7 +1041,7 @@ static ssize_t in_read(struct audio_stream_in *stream, void* buffer,
+         memset(buf_out, 0, buf_size_out);
+ 
+         ret = pcm_read(in->pcm, buf_in, buf_size_in);
+-
++        in->frames_read += frames_in;
+ #ifdef DEBUG_PCM_DUMP
+         if(sco_call_read != NULL) {
+             fwrite(buf_in, 1, buf_size_in, sco_call_read);
+@@ -1001,7 +1089,11 @@ static ssize_t in_read(struct audio_stream_in *stream, void* buffer,
+     } else {
+         /* pcm read for primary card */
+         ret = pcm_read(in->pcm, buffer, bytes);
++        in->frames_read += in->pcm_config->period_size;
+ 
++       struct aec_info info;
++       get_pcm_timestamp(in->pcm, in->pcm_config->rate, &info, false /*isOutput*/);
++       in->timestamp_nsec = audio_utils_ns_from_timespec(&info.timestamp);
+ #ifdef DEBUG_PCM_DUMP
+         if(in_read_dump != NULL) {
+             fwrite(buffer, 1, bytes, in_read_dump);
+@@ -1359,6 +1451,7 @@ static int adev_open_input_stream(struct audio_hw_device *dev,
+     in->stream.set_gain = in_set_gain;
+     in->stream.read = in_read;
+     in->stream.get_input_frames_lost = in_get_input_frames_lost;
++    in->stream.get_capture_position = getCapturePosition;
+ 
+     in->dev = adev;
+     in->standby = true;
+-- 
+2.39.1
+


### PR DESCRIPTION
Add getCapturePosition method implementation in HAL added methods to calculate time and frames read.
VtsHalAudioV7_0Target Tests Fixed

Tracked-On: OAM-105777
Signed-off-by: Kothapeta, BikshapathiX <bikshapathix.kothapeta@intel.com>