### PR TITLE
remove obsolete qemu patch

### DIFF
--- a/bsp_diff/caas/vendor/intel/utils/0005-remove-obsolete-qemu-patch.patch
+++ b/bsp_diff/caas/vendor/intel/utils/0005-remove-obsolete-qemu-patch.patch
@@ -1,0 +1,144 @@
+From 392d3f73415f0c5b53b8db88b14e8dc1effd4acd Mon Sep 17 00:00:00 2001
+From: "Chenthati, Pradeep" <pradeepx.chenthati@intel.com>
+Date: Tue, 14 Feb 2023 18:33:38 +0530
+Subject: [PATCH] remove obsolete qemu patch
+
+since qemu version 7.1.1 is used in vertical builds, this patch became obsolete
+
+Tracked-On: OAM-105834
+Signed-off-by: Chenthati, Pradeep <pradeepx.chenthati@intel.com>
+---
+ ...w-display-fix-virgl-reset-regression.patch | 121 ------------------
+ 1 file changed, 121 deletions(-)
+ delete mode 100644 host/qemu/0035-hw-display-fix-virgl-reset-regression.patch
+
+diff --git a/host/qemu/0035-hw-display-fix-virgl-reset-regression.patch b/host/qemu/0035-hw-display-fix-virgl-reset-regression.patch
+deleted file mode 100644
+index 118b4d3..0000000
+--- a/host/qemu/0035-hw-display-fix-virgl-reset-regression.patch
++++ /dev/null
+@@ -1,121 +0,0 @@
+-From 37bb84712deb87b2e94c707244b55f0953d75dc5 Mon Sep 17 00:00:00 2001
+-From: =?UTF-8?q?Marc-Andr=C3=A9=20Lureau?= <marcandre.lureau@redhat.com>
+-Date: Fri, 2 Jul 2021 16:32:21 +0400
+-Subject: [PATCH] hw/display: fix virgl reset regression
+-MIME-Version: 1.0
+-Content-Type: text/plain; charset=UTF-8
+-Content-Transfer-Encoding: 8bit
+-
+-Before commit 49afbca3b00e8e517d54964229a794b51768deaf ("virtio-gpu: drop
+-use_virgl_renderer"), use_virgl_renderer was preventing calling GL
+-functions from non-GL context threads. The innocuously looking
+-
+-  g->parent_obj.use_virgl_renderer = false;
+-
+-was set the first time virtio_gpu_gl_reset() was called, during
+-pc_machine_reset() in the main thread. Further virtio_gpu_gl_reset()
+-calls in IO threads, without associated GL context, were thus skipping
+-GL calls and avoided warnings or crashes (see also
+-https://gitlab.freedesktop.org/virgl/virglrenderer/-/issues/226).
+-
+-Signed-off-by: Marc-André Lureau <marcandre.lureau@redhat.com>
+-Message-Id: <20210702123221.942432-1-marcandre.lureau@redhat.com>
+-Signed-off-by: Gerd Hoffmann <kraxel@redhat.com>
+-Signed-off-by: chenyanxzhu <chenyanx.zhu@intel.com>
+----
+- hw/display/virtio-gpu-gl.c     | 22 +++++++++++-----------
+- hw/display/virtio-gpu-virgl.c  |  8 ++++++--
+- include/hw/virtio/virtio-gpu.h |  1 +
+- 3 files changed, 18 insertions(+), 13 deletions(-)
+-
+-diff --git a/hw/display/virtio-gpu-gl.c b/hw/display/virtio-gpu-gl.c
+-index d971b48080..aea9700d5c 100644
+---- a/hw/display/virtio-gpu-gl.c
+-+++ b/hw/display/virtio-gpu-gl.c
+-@@ -51,12 +51,7 @@ static void virtio_gpu_gl_update_cursor_data(VirtIOGPU *g,
+- static void virtio_gpu_gl_flushed(VirtIOGPUBase *b)
+- {
+-     VirtIOGPU *g = VIRTIO_GPU(b);
+--    VirtIOGPUGL *gl = VIRTIO_GPU_GL(b);
+- 
+--    if (gl->renderer_reset) {
+--        gl->renderer_reset = false;
+--        virtio_gpu_virgl_reset(g);
+--    }
+-     virtio_gpu_process_cmdq(g);
+- }
+- 
+-@@ -74,6 +69,10 @@ static void virtio_gpu_gl_handle_ctrl(VirtIODevice *vdev, VirtQueue *vq)
+-         virtio_gpu_virgl_init(g);
+-         gl->renderer_inited = true;
+-     }
+-+    if (gl->renderer_reset) {
+-+        gl->renderer_reset = false;
+-+        virtio_gpu_virgl_reset(g);
+-+    }
+- 
+-     cmd = virtqueue_pop(vq, sizeof(struct virtio_gpu_ctrl_command));
+-     while (cmd) {
+-@@ -95,12 +94,13 @@ static void virtio_gpu_gl_reset(VirtIODevice *vdev)
+- 
+-     virtio_gpu_reset(vdev);
+- 
+--    if (gl->renderer_inited) {
+--        if (g->parent_obj.renderer_blocked) {
+--            gl->renderer_reset = true;
+--        } else {
+--            virtio_gpu_virgl_reset(g);
+--        }
+-+    /*
+-+     * GL functions must be called with the associated GL context in main
+-+     * thread, and when the renderer is unblocked.
+-+     */
+-+    if (gl->renderer_inited && !gl->renderer_reset) {
+-+        virtio_gpu_virgl_reset_scanout(g);
+-+        gl->renderer_reset = true;
+-     }
+- }
+- 
+-diff --git a/hw/display/virtio-gpu-virgl.c b/hw/display/virtio-gpu-virgl.c
+-index 96591f3bf5..afd0891560 100644
+---- a/hw/display/virtio-gpu-virgl.c
+-+++ b/hw/display/virtio-gpu-virgl.c
+-@@ -606,17 +606,21 @@ void virtio_gpu_virgl_fence_poll(VirtIOGPU *g)
+-     virtio_gpu_fence_poll(g);
+- }
+- 
+--void virtio_gpu_virgl_reset(VirtIOGPU *g)
+-+void virtio_gpu_virgl_reset_scanout(VirtIOGPU *g)
+- {
+-     int i;
+- 
+--    virgl_renderer_reset();
+-     for (i = 0; i < g->parent_obj.conf.max_outputs; i++) {
+-         dpy_gfx_replace_surface(g->parent_obj.scanout[i].con, NULL);
+-         dpy_gl_scanout_disable(g->parent_obj.scanout[i].con);
+-     }
+- }
+- 
+-+void virtio_gpu_virgl_reset(VirtIOGPU *g)
+-+{
+-+    virgl_renderer_reset();
+-+}
+-+
+- int virtio_gpu_virgl_init(VirtIOGPU *g)
+- {
+-     int ret;
+-diff --git a/include/hw/virtio/virtio-gpu.h b/include/hw/virtio/virtio-gpu.h
+-index dd9f481bc7..da6e4a4150 100644
+---- a/include/hw/virtio/virtio-gpu.h
+-+++ b/include/hw/virtio/virtio-gpu.h
+-@@ -282,6 +282,7 @@ int virtio_gpu_update_dmabuf(VirtIOGPU *g,
+- void virtio_gpu_virgl_process_cmd(VirtIOGPU *g,
+-                                   struct virtio_gpu_ctrl_command *cmd);
+- void virtio_gpu_virgl_fence_poll(VirtIOGPU *g);
+-+void virtio_gpu_virgl_reset_scanout(VirtIOGPU *g);
+- void virtio_gpu_virgl_reset(VirtIOGPU *g);
+- int virtio_gpu_virgl_init(VirtIOGPU *g);
+- int virtio_gpu_virgl_get_num_capsets(VirtIOGPU *g);
+--- 
+-2.38.1
+-
+-- 
+2.39.1
+


### PR DESCRIPTION
since qemu version 7.1.1 is used in vertical builds, this patch became obsolete

Tracked-On: OAM-105834
Signed-off-by: Chenthati, Pradeep <pradeepx.chenthati@intel.com>