### PR TITLE
Media regression in CTS

### DIFF
--- a/aosp_diff/caas/external/scudo/0001-Revert-Configure-scudo-to-use-exclusive-TSD.patch
+++ b/aosp_diff/caas/external/scudo/0001-Revert-Configure-scudo-to-use-exclusive-TSD.patch
@@ -1,0 +1,51 @@
+From 28ce6aa8ee1a61f835526d8436d26d6e1cc1c8ad Mon Sep 17 00:00:00 2001
+From: "Chenthati, Pradeep" <pradeepx.chenthati@intel.com>
+Date: Tue, 21 Mar 2023 17:06:10 +0530
+Subject: [PATCH] Revert "Configure scudo to use exclusive TSD"
+
+This reverts commit 177250ca816ce153437d05887a8a7c2301de3002.
+
+configuration of scudo to use TSD exclusively causing
+multiple failures in CtsMediaTestCases, CtsMediaV2TestCases
+and CtsVideoTestCases CTS modules
+
+Tracked-On: OAM-106948
+---
+ Android.bp                    | 1 -
+ standalone/allocator_config.h | 7 +------
+ 2 files changed, 1 insertion(+), 7 deletions(-)
+
+diff --git a/Android.bp b/Android.bp
+index 378da61bdd5..60cadc91263 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -148,7 +148,6 @@ cc_library_static {
+     defaults: ["libscudo_defaults"],
+     cflags: [
+       "-D_BIONIC=1",
+-      "-DSCUDO_ANDROID_USE_EXCLUSIVETSD",
+       "-DSCUDO_HAS_PLATFORM_TLS_SLOT",
+     ],
+     visibility: [
+diff --git a/standalone/allocator_config.h b/standalone/allocator_config.h
+index 77494491880..8e103f28b1a 100644
+--- a/standalone/allocator_config.h
++++ b/standalone/allocator_config.h
+@@ -105,13 +105,8 @@ struct AndroidConfig {
+   static const s32 SecondaryCacheMinReleaseToOsIntervalMs = 0;
+   static const s32 SecondaryCacheMaxReleaseToOsIntervalMs = 1000;
+ 
+-#ifdef SCUDO_ANDROID_USE_EXCLUSIVETSD
+   template <class A>
+-  using TSDRegistryT = TSDRegistryExT<A>; // Exclusive
+-#else
+-  template <class A>
+-  using TSDRegistryT = TSDRegistrySharedT<A, 32U, 2U>; // Start with 2, max 32 TSDs
+-#endif
++  using TSDRegistryT = TSDRegistrySharedT<A, 8U, 2U>; // Shared, max 8 TSDs.
+ };
+ 
+ struct AndroidSvelteConfig {
+-- 
+2.40.0
+


### PR DESCRIPTION
This reverts commit 177250ca816ce153437d05887a8a7c2301de3002.

configuration of scudo to use TSD exclusively causing multiple failures in CtsMediaTestCases, CtsMediaV2TestCases and CtsVideoTestCases CTS modules

Tracked-On: OAM-106948