### PR TITLE
[c2][decoder] Fixed some issues when oneVPL returns resolution change

### DIFF
--- a/bsp_diff/caas/vendor/intel/mediasdk_c2/0002-Exit-the-loop-when-the-surface-may-not-be-available.patch
+++ b/bsp_diff/caas/vendor/intel/mediasdk_c2/0002-Exit-the-loop-when-the-surface-may-not-be-available.patch
@@ -1,0 +1,94 @@
+From 4b15f5e8766dcd709728c665280cad84d29e4222 Mon Sep 17 00:00:00 2001
+From: zhangyichix <yichix.zhang@intel.com>
+Date: Mon, 10 Oct 2022 06:04:24 +0000
+Subject: [PATCH] Exit the loop when the surface may not be available
+
+cases:
+android.media.decoder.cts.DecoderTest#testCodecResetsH264WithSurface
+android.media.decoder.cts.DecoderTest#testCodecResetsHEVCWithSurface
+
+From Android T, Surfaces are no longer used when MediaCodec#stop() is called.
+https://android-review.googlesource.com/c/platform/frameworks/av/+/2098075
+Exit the loop when the surface may not be available.
+
+Tracked-On: OAM-104001
+Signed-off-by: zhangyichix <yichix.zhang@intel.com>
+---
+ c2_components/include/mfx_c2_decoder_component.h |  9 +++++++++
+ c2_components/src/mfx_c2_decoder_component.cpp   | 13 ++++++++++++-
+ 2 files changed, 21 insertions(+), 1 deletion(-)
+
+diff --git a/c2_components/include/mfx_c2_decoder_component.h b/c2_components/include/mfx_c2_decoder_component.h
+index d5842cc..1e925e5 100755
+--- a/c2_components/include/mfx_c2_decoder_component.h
++++ b/c2_components/include/mfx_c2_decoder_component.h
+@@ -43,6 +43,13 @@ public:
+         DECODER_AV1,
+     };
+ 
++    enum class OperationState {
++        INITIALIZATION,
++        RUNNING,
++        STOPPING,
++        STOPPED,
++    };
++
+ protected:
+     MfxC2DecoderComponent(const C2String name, const CreateConfig& config,
+         std::shared_ptr<C2ReflectorHelper> reflector, DecoderType decoder_type);
+@@ -174,6 +181,8 @@ private:
+ 
+     bool m_bInitialized;
+ 
++    OperationState m_OperationState { OperationState::INITIALIZATION };
++
+     MfxCmdQueue m_workingQueue;
+     MFX_TRACEABLE(m_workingQueue);
+     MfxCmdQueue m_waitingQueue;
+diff --git a/c2_components/src/mfx_c2_decoder_component.cpp b/c2_components/src/mfx_c2_decoder_component.cpp
+index 55b071c..d212997 100755
+--- a/c2_components/src/mfx_c2_decoder_component.cpp
++++ b/c2_components/src/mfx_c2_decoder_component.cpp
+@@ -738,13 +738,15 @@ c2_status_t MfxC2DecoderComponent::DoStart()
+ 
+     } while(false);
+ 
++    m_OperationState = OperationState::RUNNING;
++
+     return C2_OK;
+ }
+ 
+ c2_status_t MfxC2DecoderComponent::DoStop(bool abort)
+ {
+     MFX_DEBUG_TRACE_FUNC;
+-
++    m_OperationState = OperationState::STOPPING;
+     // Working queue should stop first otherwise race condition
+     // is possible when waiting queue is stopped (first), but working
+     // queue is pushing tasks into it (via DecodeFrameAsync). As a
+@@ -780,6 +782,7 @@ c2_status_t MfxC2DecoderComponent::DoStop(bool abort)
+         m_c2Bitstream->GetFrameConstructor()->Close();
+     }
+ 
++    m_OperationState = OperationState::STOPPED;
+     return C2_OK;
+ }
+ 
+@@ -1740,6 +1743,14 @@ c2_status_t MfxC2DecoderComponent::AllocateC2Block(uint32_t width, uint32_t heig
+             break;
+         }
+ 
++        // From Android T, Surfaces are no longer used when MediaCodec#stop() is called.
++        // https://android-review.googlesource.com/c/platform/frameworks/av/+/2098075
++        // Exit the loop when the surface may not be available.
++        if (OperationState::STOPPING == m_OperationState) {
++            res = C2_CANCELED;
++            break;
++        }
++
+         if (m_mfxVideoParams.IOPattern == MFX_IOPATTERN_OUT_VIDEO_MEMORY) {
+ 
+             C2MemoryUsage mem_usage = {m_consumerUsage, C2AndroidMemoryUsage::HW_CODEC_WRITE};
+-- 
+2.40.0
+

--- a/bsp_diff/caas/vendor/intel/mediasdk_c2/0003-c2-decoder-Fixed-some-issues-when-oneVPL-returns-res.patch
+++ b/bsp_diff/caas/vendor/intel/mediasdk_c2/0003-c2-decoder-Fixed-some-issues-when-oneVPL-returns-res.patch
@@ -1,0 +1,120 @@
+From b941fdf8b6d52774026e4784026f349d008e09dd Mon Sep 17 00:00:00 2001
+From: gollarx <ratnakumarix.golla@intel.com>
+Date: Tue, 28 Mar 2023 16:29:13 +0530
+Subject: [PATCH] [c2][decoder] Fixed some issues when oneVPL returns
+ resolution change
+
+case: widevineH264AdaptiveWithRendererDisablingV18
+
+1. prevent deleting bs which in use.
+2. when oneVPL returns an error of resolution change,
+it is not necessarily the width or height has changed.
+however, we reinit the codec.
+3. when deleting a work if it is not found, do not return a fatal
+error directly.
+
+Tracked-On: OAM-104972
+Signed-off-by: gollarx <ratnakumarix.golla@intel.com>
+---
+ .../src/mfx_c2_decoder_component.cpp          | 46 +++++++++----------
+ 1 file changed, 22 insertions(+), 24 deletions(-)
+
+diff --git a/c2_components/src/mfx_c2_decoder_component.cpp b/c2_components/src/mfx_c2_decoder_component.cpp
+index d212997..c90336c 100755
+--- a/c2_components/src/mfx_c2_decoder_component.cpp
++++ b/c2_components/src/mfx_c2_decoder_component.cpp
+@@ -1289,7 +1289,6 @@ mfxStatus MfxC2DecoderComponent::HandleFormatChange()
+ 
+     if (!m_mfxDecoder) return MFX_ERR_NULL_PTR;
+ 
+-    bool need_realloc = false;
+     mfx_res = m_mfxDecoder->DecodeHeader(m_c2Bitstream->GetFrameConstructor()->GetMfxBitstream().get(), &m_mfxVideoParams);
+     MFX_DEBUG_TRACE__mfxStatus(mfx_res);
+     if (MFX_ERR_NONE == mfx_res) {
+@@ -1297,31 +1296,26 @@ mfxStatus MfxC2DecoderComponent::HandleFormatChange()
+         mfxFrameAllocRequest decRequest = {};
+         mfx_res = m_mfxDecoder->QueryIOSurf(&m_mfxVideoParams, &decRequest);
+         if (MFX_ERR_NONE == mfx_res) {
+-            if (m_mfxVideoParams.mfx.FrameInfo.Width != m_uMaxWidth ||
+-                m_mfxVideoParams.mfx.FrameInfo.Height != m_uMaxHeight) {
+-                need_realloc = true;
+-            } else if (m_uOutputDelay < decRequest.NumFrameSuggested){
++            if (m_uOutputDelay < decRequest.NumFrameSuggested){
+                 // This should never happen here as buffers with the maximum count are allocated
+                 return MFX_ERR_MEMORY_ALLOC;
+             }
+-
+-            if (need_realloc) {
+-                // Free all the surfaces
+-                mfx_res = m_mfxDecoder->Close();
+-                if (MFX_ERR_NONE == mfx_res) {
+-                    // De-allocate all the surfaces
+-                    m_lockedSurfaces.clear();
+-                    FreeSurfaces();
+-                    if (m_allocator) {
+-                        m_allocator->Reset();
+-                    }
+-                    // Re-init decoder
+-                    m_bInitialized = false;
+-                    m_uMaxWidth = m_mfxVideoParams.mfx.FrameInfo.Width;
+-                    m_uMaxHeight = m_mfxVideoParams.mfx.FrameInfo.Height;
+-                }
+-            }
++	}
++    }
++ 
++    // Free all the surfaces
++    mfx_res = m_mfxDecoder->Close();
++    if (MFX_ERR_NONE == mfx_res) {
++        // De-allocate all the surfaces
++        m_lockedSurfaces.clear();
++        FreeSurfaces();
++        if (m_allocator) {
++            m_allocator->Reset();
+         }
++        // Re-init decoder
++        m_bInitialized = false;
++        m_uMaxWidth = m_mfxVideoParams.mfx.FrameInfo.Width;
++        m_uMaxHeight = m_mfxVideoParams.mfx.FrameInfo.Height;
+     }
+ 
+     return mfx_res;
+@@ -1947,6 +1941,7 @@ void MfxC2DecoderComponent::EmptyReadViews(uint64_t timestamp, uint64_t frame_in
+ 
+     if (!IsDuplicatedTimeStamp(timestamp)) {
+         ReleaseReadViews(frame_index);
++	return;
+     }
+ 
+     auto it = m_duplicatedTimeStamp.begin();
+@@ -2170,8 +2165,9 @@ void MfxC2DecoderComponent::DoWork(std::unique_ptr<C2Work>&& work)
+                 work = std::move(it->second);
+                 m_pendingWorks.erase(it);
+             } else {
+-                MFX_DEBUG_TRACE_STREAM("Not found C2Work to return error result!!!");
+-                FatalError(C2_CORRUPTED);
++                MFX_DEBUG_TRACE_STREAM("Not found C2Work, index = " << incoming_frame_index.peeku());
++		// If not found, it might be removed by WaitWork. We don't need to return an error.
++                // FatalError(C2_CORRUPTED);
+             }
+         }
+         if (work) {
+@@ -2309,6 +2305,7 @@ void MfxC2DecoderComponent::WaitWork(MfxC2FrameOut&& frame_out, mfxSyncPoint syn
+ 
+         if (it != m_pendingWorks.end()) {
+             work = std::move(it->second);
++	    MFX_DEBUG_TRACE_STREAM("Work removed: " << NAMED(work->input.ordinal.frameIndex.peeku()));
+             m_pendingWorks.erase(it);
+         }
+     }
+@@ -2438,6 +2435,7 @@ void MfxC2DecoderComponent::PushPending(std::unique_ptr<C2Work>&& work)
+     auto it = m_pendingWorks.find(incoming_frame_index);
+     if (it != m_pendingWorks.end()) { // Shouldn't be the same index there
+         NotifyWorkDone(std::move(it->second), C2_CORRUPTED);
++	MFX_DEBUG_TRACE_STREAM("Work removed: " << NAMED(it->second->input.ordinal.frameIndex.peeku()));
+         m_pendingWorks.erase(it);
+     }
+     m_pendingWorks.emplace(incoming_frame_index, std::move(work));
+-- 
+2.40.0
+


### PR DESCRIPTION
case: widevineH264AdaptiveWithRendererDisablingV18

1. prevent deleting bs which in use.
2. when oneVPL returns an error of resolution change, it is not necessarily the width or height has changed. however, we reinit the codec.
3. when deleting a work if it is not found, do not return a fatal error directly.
4. Exit the loop when the surface may not be available

Tracked-On: OAM-104972