### PR TITLE
[c2][decoder] fix an issue create av1 decoder using more memory

### DIFF
--- a/bsp_diff/caas/vendor/intel/mediasdk_c2/0005-c2-decoder-fix-an-issue-create-av1-decoder-using-mor.patch
+++ b/bsp_diff/caas/vendor/intel/mediasdk_c2/0005-c2-decoder-fix-an-issue-create-av1-decoder-using-mor.patch
@@ -1,0 +1,33 @@
+From 51b7b122b9c1a310830ab6752ccb73d30e13ad68 Mon Sep 17 00:00:00 2001
+From: gollarx <ratnakumarix.golla@intel.com>
+Date: Mon, 17 Apr 2023 15:44:04 +0530
+Subject: [PATCH] [c2][decoder] fix an issue create av1 decoder using more
+ memory
+
+case: android.media.codec.cts.MediaCodecCapabilitiesTest#
+testGetMaxSupportedInstances
+
+Reduced the default value of max picture size on av1 decoder.
+
+Tracked-On: OAM-106762
+Signed-off-by: gollarx <ratnakumarix.golla@intel.com>
+---
+ c2_components/src/mfx_c2_decoder_component.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/c2_components/src/mfx_c2_decoder_component.cpp b/c2_components/src/mfx_c2_decoder_component.cpp
+index 55b071c..25c2888 100755
+--- a/c2_components/src/mfx_c2_decoder_component.cpp
++++ b/c2_components/src/mfx_c2_decoder_component.cpp
+@@ -493,7 +493,7 @@ MfxC2DecoderComponent::MfxC2DecoderComponent(const C2String name, const CreateCo
+ 
+             addParameter(
+                 DefineParam(m_maxSize, C2_PARAMKEY_MAX_PICTURE_SIZE)
+-                .withDefault(new C2StreamMaxPictureSizeTuning::output(SINGLE_STREAM_ID, WIDTH_8K, HEIGHT_8K))
++                .withDefault(new C2StreamMaxPictureSizeTuning::output(SINGLE_STREAM_ID, MIN_W, MIN_H))
+                 .withFields({
+                     C2F(m_size, width).inRange(2, WIDTH_8K, 2),
+                     C2F(m_size, height).inRange(2, HEIGHT_8K, 2),
+-- 
+2.40.0
+


### PR DESCRIPTION
case: android.media.codec.cts.MediaCodecCapabilitiesTest#testGetMaxSupportedInstances

Reduced the default value of max picture size on av1 decoder.

Tracked-On: OAM-106762