### PR TITLE
Revert WA to retrieve the entire supported modelist from HwComposer

### DIFF
--- a/bsp_diff/caas/vendor/intel/utils_vertical_priv/0001-Revert-WA-to-retrieve-the-entire-supported-modelist-.patch
+++ b/bsp_diff/caas/vendor/intel/utils_vertical_priv/0001-Revert-WA-to-retrieve-the-entire-supported-modelist-.patch
@@ -1,0 +1,46 @@
+From 7ec8106560f16dc1744639a77ef8d80342eb1949 Mon Sep 17 00:00:00 2001
+From: "Kothapeta, BikshapathiX" <bikshapathix.kothapeta@intel.com>
+Date: Mon, 24 Apr 2023 11:44:33 +0530
+Subject: [PATCH] Revert "WA to retrieve the entire supported modelist from
+ HwComposer"
+
+This reverts commit abe12ac5493cbbd4252f65a1676387f0315521ff.
+
+diff --git a/bsp_diff/caas/vendor/intel/external/drm-hwcomposer/0001-Wa-to-retrieve-the-entire-supported-modelist-from-hw.patch b/bsp_diff/caas/vendor/intel/external/drm-hwcomposer/0001-Wa-to-retrieve-the-entire-supported-modelist-from-hw.patch
+deleted file mode 100644
+index aaf2241..0000000
+--- a/bsp_diff/caas/vendor/intel/external/drm-hwcomposer/0001-Wa-to-retrieve-the-entire-supported-modelist-from-hw.patch
++++ /dev/null
+@@ -1,29 +0,0 @@
+-From a9fe8d18e557b524e5a151a5b89e53aff2377382 Mon Sep 17 00:00:00 2001
+-From: kalle <kalyan.alle@intel.com>
+-Date: Fri, 13 Jan 2023 15:01:40 +0530
+-Subject: [PATCH] Wa to retrieve the entire supported modelist from hwcomposer
+-
+-Set the default value to 0 for preferred modelist limit property.
+-
+-Tracked-On: OAM-105464
+-Signed-off-by: Shekhar Chauhan shekhar.chauhan@intel.com
+----
+- drm/DrmDevice.cpp | 2 +-
+- 1 file changed, 1 insertion(+), 1 deletion(-)
+-
+-diff --git a/drm/DrmDevice.cpp b/drm/DrmDevice.cpp
+-index c8662dd..9ecbdfb 100755
+---- a/drm/DrmDevice.cpp
+-+++ b/drm/DrmDevice.cpp
+-@@ -102,7 +102,7 @@ auto DrmDevice::Init(const char *path) -> int {
+- 
+-   char property[PROPERTY_VALUE_MAX];
+-   memset(property, 0 , PROPERTY_VALUE_MAX);
+--  property_get("vendor.hwcomposer.preferred.mode.limit", property, "1");
+-+  property_get("vendor.hwcomposer.preferred.mode.limit", property, "0");
+-   preferred_mode_limit_ = atoi(property) != 0 ? true : false;
+-   ALOGD("The property 'vendor.hwcomposer.preferred.mode.limit' value is %d", preferred_mode_limit_);
+- 
+--- 
+-2.17.1
+-
+-- 
+2.40.0
+


### PR DESCRIPTION
Set the default value to 0 for preferred modelist limited property

Tracked-On: OAM-108818