### PR TITLE
Accept null or empty for show_fps

### DIFF
--- a/host/vm-manager/0002-Accept-null-or-empty-for-show_fps.patch
+++ b/host/vm-manager/0002-Accept-null-or-empty-for-show_fps.patch
@@ -1,0 +1,26 @@
+From a77f341aad557f7bd98295f4fc262a051f5c00e2 Mon Sep 17 00:00:00 2001
+From: "Suresh, Prashanth" <prashanth.suresh@intel.com>
+Date: Wed, 26 Apr 2023 18:37:11 +0530
+Subject: [PATCH] Accept null or empty for show_fps
+
+---
+ src/guest/start.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/guest/start.c b/src/guest/start.c
+index 5ce17c6..36f7ae3 100644
+--- a/src/guest/start.c
++++ b/src/guest/start.c
+@@ -563,6 +563,9 @@ static int setup_sriov(GKeyFile *gkf, char **p, size_t *size)
+ 	show_fps = g_key_file_get_string(gkf, g->name, g->key[SHOW_FPS], &error);
+ 	if (show_fps != NULL &&  (!strcmp(show_fps,"on") || !strcmp(show_fps,"off")))
+ 		strcat(show_fps_str, show_fps);
++	else if (show_fps == NULL || !strcmp(show_fps, "")){
++		strcat(show_fps_str, "off");
++	}
+ 	else {
+ 		fprintf(stderr, "Please enter a valid value for show_fps.\n");
+ 		return -1;
+-- 
+2.34.1
+


### PR DESCRIPTION
Set default to off when show_fps is null or empty.

Tracked-On: OAM-109700