### PR TITLE
Enable trusty and revert kernelflinger workaround

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0026-Enable-trusty-on-android-15-kernel.patch
+++ b/bsp_diff/caas/device/intel/mixins/0026-Enable-trusty-on-android-15-kernel.patch
@@ -1,0 +1,24 @@
+From a7131f91a809ec872f1217e783880807860ef193 Mon Sep 17 00:00:00 2001
+From: Avinash Kumar <avinash3.kumar@intel.com>
+Date: Fri, 26 Sep 2025 05:55:42 +0000
+Subject: [PATCH] Enable trusty on android 15 kernel
+
+Enable all trusty related kernel compile flags for android15 build.
+
+Signed-off-by: Avinash Kumar <avinash3.kumar@intel.com>
+---
+ .../kernel/gmin64/config-lts/linux-intel-lts2024/caas_diffconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/groups/kernel/gmin64/config-lts/linux-intel-lts2024/caas_diffconfig b/groups/kernel/gmin64/config-lts/linux-intel-lts2024/caas_diffconfig
+index 9fc72cd5..d47ec583 100644
+--- a/groups/kernel/gmin64/config-lts/linux-intel-lts2024/caas_diffconfig
++++ b/groups/kernel/gmin64/config-lts/linux-intel-lts2024/caas_diffconfig
+@@ -1,3 +1,4 @@
++CONFIG_TEE=y
+ CONFIG_TRUSTY=y
+ # CONFIG_TRUSTY_IRQ is not set
+ CONFIG_TRUSTY_LOG=y
+-- 
+2.34.1
+

--- a/bsp_diff/caas/hardware/intel/kernelflinger/0001-Revert-kernelflinger-patch.patch
+++ b/bsp_diff/caas/hardware/intel/kernelflinger/0001-Revert-kernelflinger-patch.patch
@@ -1,0 +1,29 @@
+From 30b6f03209e0005756b6f8c9e135d75b28e67028 Mon Sep 17 00:00:00 2001
+From: Basanagouda Nagappa Koppad <Basanagouda.Nagappa.Koppad@intel.com>
+Date: Wed, 24 Sep 2025 07:02:26 +0000
+Subject: [PATCH] Revert kernelflinger patch
+
+revert commit id# 38b71582d0d93b11e4710f5c75f2b1d5cafa2261
+
+Signed-off-by: Basanagouda Nagappa Koppad <Basanagouda.Nagappa.Koppad@intel.com>
+
+diff --git a/libkernelflinger/android.c b/libkernelflinger/android.c
+index 9944529..58ea694 100644
+--- a/libkernelflinger/android.c
++++ b/libkernelflinger/android.c
+@@ -479,6 +479,12 @@ static inline EFI_STATUS handover_jump(EFI_HANDLE image,
+         return ret;
+ 
+ boot:
++#ifdef USE_TRUSTY
++        /*
++         * Called after ExitBootService.
++         */
++        trusty_late_init();
++#endif
+ 
+ #if __LP64__
+         /* The 64-bit kernel entry is 512 bytes after the start. */
+-- 
+2.34.1
+


### PR DESCRIPTION
Enable all trusty related kernel compile flags for android15 build. Also revert kernelflinger prior workaround.

Tracked-On: OAM-134102