### PR TITLE
[TWL] Enable TPM config by default to y

### DIFF
--- a/bsp_diff/caas/device/intel/mixins/0027-TWL-Enable-TPM-config-by-default-to-y.patch
+++ b/bsp_diff/caas/device/intel/mixins/0027-TWL-Enable-TPM-config-by-default-to-y.patch
@@ -1,0 +1,51 @@
+From 51e8883df3e33a0eea5f97d01d89ce470f600a02 Mon Sep 17 00:00:00 2001
+From: Basanagouda Nagappa Koppad <Basanagouda.Nagappa.Koppad@intel.com>
+Date: Wed, 5 Nov 2025 03:29:24 +0000
+Subject: [PATCH] [TWL] Enable TPM config by default to y
+
+DA lockout counter was incrementing due to an improper TPM shutdown
+Kernel TPM driver - no TPM driver was present in the kernel,
+enabled TPM driver for PTT, need to enable dTPM driver as well,
+as the customer platform may use dTPM.
+
+With this, on reboot command, the TPM driver in the
+kernel will send the appropriate TPM2 shutdown command to TPM and that
+will prevent the DA counter from incrementing on each boot.
+
+Tracked-On: OAM-134432
+Signed-off-by: Basanagouda Nagappa Koppad <Basanagouda.Nagappa.Koppad@intel.com>
+
+diff --git a/groups/kernel/gmin64/config-lts/linux-intel-lts2024/x86_64_defconfig b/groups/kernel/gmin64/config-lts/linux-intel-lts2024/x86_64_defconfig
+index 0fbbea6a..b4c11918 100644
+--- a/groups/kernel/gmin64/config-lts/linux-intel-lts2024/x86_64_defconfig
++++ b/groups/kernel/gmin64/config-lts/linux-intel-lts2024/x86_64_defconfig
+@@ -3084,7 +3084,7 @@ CONFIG_NVRAM=y
+ # CONFIG_DEVPORT is not set
+ # CONFIG_HPET is not set
+ # CONFIG_HANGCHECK_TIMER is not set
+-CONFIG_TCG_TPM=m
++CONFIG_TCG_TPM=y
+ CONFIG_TCG_TPM2_HMAC=y
+ CONFIG_HW_RANDOM_TPM=y
+ CONFIG_TCG_TIS_CORE=m
+@@ -3098,7 +3098,7 @@ CONFIG_TCG_TIS_I2C_NUVOTON=m
+ CONFIG_TCG_NSC=m
+ CONFIG_TCG_ATMEL=m
+ CONFIG_TCG_INFINEON=m
+-CONFIG_TCG_CRB=m
++CONFIG_TCG_CRB=y
+ # CONFIG_TCG_VTPM_PROXY is not set
+ # CONFIG_TCG_TIS_ST33ZP24_I2C is not set
+ # CONFIG_TCG_TIS_ST33ZP24_SPI is not set
+@@ -7732,7 +7732,7 @@ CONFIG_ARCH_USE_SYM_ANNOTATIONS=y
+ #
+ CONFIG_CRYPTO_LIB_UTILS=y
+ CONFIG_CRYPTO_LIB_AES=y
+-CONFIG_CRYPTO_LIB_AESCFB=m
++CONFIG_CRYPTO_LIB_AESCFB=y
+ CONFIG_CRYPTO_LIB_ARC4=y
+ CONFIG_CRYPTO_LIB_GF128MUL=y
+ CONFIG_CRYPTO_ARCH_HAVE_LIB_BLAKE2S=y
+-- 
+2.34.1
+


### PR DESCRIPTION
    DA lockout counter was incrementing due to an improper TPM shutdown
    Kernel TPM driver - no TPM driver was present in the kernel,
    enabled TPM driver for PTT, need to enable dTPM driver as well,
    as the customer platform may use dTPM.

    With this, on reboot command, the TPM driver in the
    kernel will send the appropriate TPM2 shutdown command to TPM and
that
    will prevent the DA counter from incrementing on each boot.

Tracked-On: OAM-134432